### PR TITLE
Fix Ruby 2.7 Warnings

### DIFF
--- a/process-group.gemspec
+++ b/process-group.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
 	
 	spec.add_development_dependency "covered"
 	spec.add_development_dependency "bundler"
-	spec.add_development_dependency "rspec", "~> 3.4.0"
+	spec.add_development_dependency "rspec", "~> 3.9.0"
 	spec.add_development_dependency "rake"
 end

--- a/spec/process/group/interrupt_spec.rb
+++ b/spec/process/group/interrupt_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Process::Group do
 			checkpoint += 'A'
 			
 			# This never returns:
-			result = subject.fork do
+			subject.fork do
 				# We do this to exit immediately.. otherwise Ruby will print a backtrace and that's a bit confusing.
 				trap(:INT) { exit!(0) }
 				sleep(0.2)
@@ -79,7 +79,7 @@ RSpec.describe Process::Group do
 			checkpoint += 'A'
 		
 			# This never returns:
-			result = subject.fork { sleep 0.2 }
+			subject.fork { sleep 0.2 }
 		
 			checkpoint += 'B'
 		end.resume

--- a/spec/process/group/wait_spec.rb
+++ b/spec/process/group/wait_spec.rb
@@ -22,8 +22,6 @@ require 'process/group'
 
 RSpec.describe Process::Group do
 	it "should invoke child task normally" do
-		start_time = Time.now
-		
 		child_exit_status = nil
 		
 		subject.wait do
@@ -36,8 +34,6 @@ RSpec.describe Process::Group do
 	end
 	
 	it "should kill child task if process is interrupted" do
-		start_time = Time.now
-		
 		child_exit_status = nil
 		
 		expect do


### PR DESCRIPTION
warning: Using the last argument as keyword parameters is deprecatedwarning: Using the last argument as keyword parameters is deprecated